### PR TITLE
added support for RSS feed fields containing ":" char

### DIFF
--- a/core/components/getfeed/snippet.getfeed.php
+++ b/core/components/getfeed/snippet.getfeed.php
@@ -29,6 +29,13 @@ if (!empty($url) && $modx->getService('rss', 'xmlrss.modRSSParser')) {
         $idx = 0;
         while (list($itemKey, $item) = each($rss->items)) {
             if ($idx >= $offset) {
+                foreach ($item as $k => $v) {
+                    if (is_array($v)) {
+                        foreach ($v as $k2 => $v2) {
+                            $item[$k . '-' . $k2] = $v2;
+                        }
+                    }
+                }
                 if (!empty($tpl)) {
                     $output[] = $modx->getChunk($tpl, $item);
                 } else {


### PR DESCRIPTION
added support for RSS feed fields containing ":" char (for example dc:creator) - snippet cannot store array value to placeholder, my solution adds new field with name created from key form first level array and second level array (for example RSS field dc:creatorcan be accessen in placeholder [[+dc-creator]] and so on)
